### PR TITLE
Fix try-catch

### DIFF
--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -1,6 +1,7 @@
 name: Code style check
 
 on:
+  workflow_dispatch:
   push:
     branches:
     - main

--- a/src/main.c
+++ b/src/main.c
@@ -56,6 +56,16 @@ void dispatch_plugin_calls(int message, void *parameters) {
     }
 }
 
+void handle_query_ui_exception(unsigned int *args) {
+    switch (args[0]) {
+        case ETH_PLUGIN_QUERY_CONTRACT_UI:
+            ((ethQueryContractUI_t *) args[1])->result = ETH_PLUGIN_RESULT_ERROR;
+            break;
+        default:
+            break;
+    }
+}
+
 // Calls the ethereum app.
 void call_app_ethereum() {
     unsigned int libcall_params[3];
@@ -93,12 +103,23 @@ __attribute__((section(".boot"))) int main(int arg0) {
                 if (args[0] != ETH_PLUGIN_CHECK_PRESENCE) {
                     dispatch_plugin_calls(args[0], (void *) args[1]);
                 }
-
-                // Call `os_lib_end`, go back to the ethereum app.
-                os_lib_end();
             }
         }
+        CATCH_OTHER(e) {
+            switch (e) {
+                // These exceptions are only generated on handle_query_contract_ui()
+                case 0x6502:
+                case EXCEPTION_OVERFLOW:
+                    handle_query_ui_exception((unsigned int *) arg0);
+                    break;
+                default:
+                    break;
+            }
+            PRINTF("Exception 0x%x caught\n", e);
+        }
         FINALLY {
+            // Call `os_lib_end`, go back to the ethereum app.
+            os_lib_end();
         }
     }
     END_TRY;


### PR DESCRIPTION
Currently exceptions were not being caught, which means that when an exception is raised the app crashes.
Such exceptions can be raised from the plugin side, more specifically, only from the
`handle_query_contract_ui()` which eventually can call `u64_to_string`, `amountToString`.